### PR TITLE
Update to 4.2.0

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,1 +1,0 @@
-%PYTHON% setup.py install

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.1.0" %}
+{% set version = "4.2.0" %}
 
 package:
   name: nbconvert
@@ -7,7 +7,7 @@ package:
 source:
   fn: nbconvert-{{ version }}.tar.gz
   url: https://github.com/jupyter/nbconvert/archive/{{ version }}.tar.gz
-  md5: 06655576713ba1ff7cece2b92760c187
+  sha256: 32394be5a20f39f99fabfb9b2f2625df17f1c2a6699182ca41598e98e7cc9610
 
 build:
   number: 0
@@ -26,6 +26,7 @@ requirements:
     - traitlets
     - jupyter_core
     - nbformat
+    - entrypoints
 
 test:
   imports:


### PR DESCRIPTION
```
nbconvert 4.2. This includes many fixes and improvements to latex/pdf exporting, ANSI color handling, and executing notebooks with the --execute flag, as well as the usual assortment of fixes throughout.

The main new features are:

converting notebooks piped to nbconvert with the --stdin flag.
Making it easier to define custom Exporters, and the ability to register them with nbconvert via entrypoints.
```

PS: I also remove the `bld.bat`. Let's see how that goes.