### PR TITLE
Release 5.2.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.1.1" %}
+{% set version = "5.2.1" %}
 
 package:
   name: nbconvert
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: nbconvert-{{ version }}.tar.gz
-  url: https://github.com/jupyter/nbconvert/archive/{{ version }}.tar.gz
-  sha256: 1502366caab4f1aa86adebc9def492448f69310c88e52d0998c8edf2d97617ad 
+  url: https://pypi.io/packages/source/n/nbconvert/nbconvert-{{ version }}.tar.gz
+  sha256: 9ed68ec7fe90a8672b43795b29ea91cc75ea355c83debc83ebd12171521ec274
 
 build:
   number: 1
@@ -24,7 +24,7 @@ requirements:
     - entrypoints >=0.2.2
     - jinja2
     - jupyter_core
-    - jupyter_client
+    - jupyter_client >=4.2
     - mistune >0.6
     - nbformat
     - pandoc


### PR DESCRIPTION
There is no 5.2.0 (uploaded to PyPI and immediately removed).
I switched from GitHub to PyPI.io.

The hash of The GitHub tgz and PyPI.io are different though I'm unsure
what to think, but ut may be the GitHub tgz is autogenerated from the
repo.

--- 

cc @mpacer 