### PR TITLE
Add python as a run requirement

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -22,7 +22,7 @@ jobs:
   # configure qemu binfmt-misc running.  This allows us to run docker containers 
   # embedded qemu-static
   - script: |
-      docker run --rm --privileged multiarch/qemu-user-static:register
+      docker run --rm --privileged multiarch/qemu-user-static:register --reset --credential yes
       ls /proc/sys/fs/binfmt_misc/
     condition: not(startsWith(variables['CONFIG'], 'linux_64'))
     displayName: Configure binfmt_misc

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,9 +6,3 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
-pin_run_as_build:
-  python:
-    min_pin: x.x
-    max_pin: x.x
-python:
-- '2.7'

--- a/.ci_support/linux_.yaml
+++ b/.ci_support/linux_.yaml
@@ -6,3 +6,9 @@ channel_targets:
 - conda-forge main
 docker_image:
 - condaforge/linux-anvil-comp7
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- '2.7'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,6 +20,7 @@ requirements:
     - python
     - pip
   run:
+    - python
     - mistune >=0.8.1
     - jinja2
     - pygments

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 302554a2e219bc0fc84f3edd3e79953f3767b46ab67626fdec16e38ba3f7efe4
 
 build:
-  number: 0
+  number: 1
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   noarch: python
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,6 +55,7 @@ test:
 about:
   home: http://jupyter.org
   license: BSD-3-Clause
+  license_file: LICENSE
   summary: 'Converting Jupyter Notebooks'
   description: |
     The nbconvert tool, jupyter nbconvert, converts notebooks to various other


### PR DESCRIPTION
This package somehow ended up not having `python` as a `run` requirement, which we correct in this PR.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/conda_smithy.html#how-to-re-render ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
