### PR TITLE
unpin pandoc

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 302554a2e219bc0fc84f3edd3e79953f3767b46ab67626fdec16e38ba3f7efe4
 
 build:
-  number: 1
+  number: 2
   script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv"
   noarch: python
   entry_points:
@@ -32,7 +32,7 @@ requirements:
     - pandocfilters >=1.4.1
     - testpath
     - defusedxml
-    - pandoc >=1.12.1,<2.0.0
+    - pandoc >=1.12.1
 
 test:
   imports:


### PR DESCRIPTION
while nbconvert will warn about possible issues in pandoc 2, there don't appear to be real compatibility problems

see https://github.com/jupyter/nbconvert/pull/964

So I think that seeing warnings about too-new pandoc is better than the current result of pinning down pandoc (which is picking old nbconvert)

closes #27