### PR TITLE
Test for pandoc version range

### DIFF
--- a/recipe/check_pandoc.py
+++ b/recipe/check_pandoc.py
@@ -1,0 +1,18 @@
+print("Comparing recipe spec and nbconvert for pandoc:")
+import sys
+import subprocess
+
+print("... PANDOC VERSION       ", flush=True)
+
+print(subprocess.check_output(["pandoc", "--version"]).decode("utf-8"), flush=True)
+
+recipe_spec = tuple(sys.argv[1:3])
+
+print("... RECIPE PANDOC SPEC   ", recipe_spec, flush=True)
+
+from nbconvert.utils import pandoc
+pandoc_spec = (f">={pandoc._minimal_version}", f"<{pandoc._maximal_version}")
+
+print("... NBCONVERT PANDOC SPEC", pandoc_spec, flush=True)
+
+assert recipe_spec == pandoc_spec

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,12 @@
 {% set version = "7.2.10" %}
-{% set build = 0 %}
+{% set build = 1 %}
+
+{% set min_pandoc = "1.12.1" %}
+{% set max_pandoc = "" %}
+
+# expected
+# _minimal_version = "1.12.1"
+# _maximal_version = "3.0.0"
 
 package:
   name: nbconvert-meta
@@ -77,7 +84,8 @@ outputs:
         - traitlets >=5.0
       run_constrained:
         # other packages carry the full `run` dependency
-        - pandoc >=1.12.1
+        - pandoc >={{ min_pandoc }}
+        #                          ,<{{ max_pandoc }}
         - pyppeteer >=1,<1.1
         # avoid mixing nbconvert-core and pre-split nbconvert
         # should be {{ pin_subpackage("nbconvert", exact=True) }}
@@ -137,6 +145,8 @@ outputs:
         - pandoc
         - python >=3.7
     test:
+      files:
+        - check_pandoc.py
       requires:
         - pip
       commands:
@@ -145,6 +155,7 @@ outputs:
         - jupyter dejavu --version
         - jupyter nbconvert --help
         - jupyter dejavu --help
+        - python check_pandoc.py ">={{ min_pandoc }}" "<{{ max_pandoc }}"
     about:
       description: nbconvert with extra packages for pandoc-based outputs
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,11 +2,7 @@
 {% set build = 1 %}
 
 {% set min_pandoc = "1.12.1" %}
-{% set max_pandoc = "" %}
-
-# expected
-# _minimal_version = "1.12.1"
-# _maximal_version = "3.0.0"
+{% set max_pandoc = "3.0.0" %}
 
 package:
   name: nbconvert-meta
@@ -84,8 +80,7 @@ outputs:
         - traitlets >=5.0
       run_constrained:
         # other packages carry the full `run` dependency
-        - pandoc >={{ min_pandoc }}
-        #                          ,<{{ max_pandoc }}
+        - pandoc >={{ min_pandoc }},<{{ max_pandoc }}
         - pyppeteer >=1,<1.1
         # avoid mixing nbconvert-core and pre-split nbconvert
         # should be {{ pin_subpackage("nbconvert", exact=True) }}


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

References:
- ensures future versions don't regress on #94
- alternative to #95

Changes:
- [x] adds a script to print and check the pandoc version against the as-imported library
  - [x] see a failure in CI
- [x] update specs, see failure go away
  - [ ] add top pin of `3.0.0`
- [ ] figure out longer-term plan
  - run full `test` suite?
  - run a `downstream` test that uses pandoc?
  - advocate upstream for a more canonical/public place to store the pandoc range