### PR TITLE
Remove nbconvert-webpdf, add nbconvert-qtpdf

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -42,6 +42,14 @@ setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 
 source run_conda_forge_build_setup
 
+
+# Install the yum requirements defined canonically in the
+# "recipe/yum_requirements.txt" file. After updating that file,
+# run "conda smithy rerender" and this line will be updated
+# automatically.
+/usr/bin/sudo -n yum install -y mesa-libGL xorg-x11-server-Xvfb
+
+
 # make the build number clobber
 make_build_number "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,6 @@ Package license:
 
 nbconvert with extra packages for pandoc-based outputs
 
-About nbconvert-webpdf
-----------------------
-
-
-
-Package license: 
-
-nbconvert with extra packages for browser-based PDF generation
-
 About nbconvert-all
 -------------------
 
@@ -71,7 +62,6 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--all-green.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--core-green.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--pandoc-green.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) |
-| [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--webpdf-green.svg)](https://anaconda.org/conda-forge/nbconvert-webpdf) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-webpdf.svg)](https://anaconda.org/conda-forge/nbconvert-webpdf) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-webpdf.svg)](https://anaconda.org/conda-forge/nbconvert-webpdf) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-webpdf.svg)](https://anaconda.org/conda-forge/nbconvert-webpdf) |
 
 Installing nbconvert
 ====================
@@ -83,16 +73,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `nbconvert, nbconvert-all, nbconvert-core, nbconvert-pandoc, nbconvert-webpdf` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `nbconvert, nbconvert-all, nbconvert-core, nbconvert-pandoc` can be installed with `conda`:
 
 ```
-conda install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc nbconvert-webpdf
+conda install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc
 ```
 
 or with `mamba`:
 
 ```
-mamba install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc nbconvert-webpdf
+mamba install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc
 ```
 
 It is possible to list all of the versions of `nbconvert` available on your platform with `conda`:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,15 @@ Package license:
 
 nbconvert with extra packages for pandoc-based outputs
 
+About nbconvert-qtpdf
+---------------------
+
+
+
+Package license: 
+
+nbconvert with extra packages for browser-based PDF generation
+
 About nbconvert-all
 -------------------
 
@@ -62,6 +71,7 @@ Current release info
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--all-green.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-all.svg)](https://anaconda.org/conda-forge/nbconvert-all) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--core-green.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-core.svg)](https://anaconda.org/conda-forge/nbconvert-core) |
 | [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--pandoc-green.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-pandoc.svg)](https://anaconda.org/conda-forge/nbconvert-pandoc) |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-nbconvert--qtpdf-green.svg)](https://anaconda.org/conda-forge/nbconvert-qtpdf) | [![Conda Downloads](https://img.shields.io/conda/dn/conda-forge/nbconvert-qtpdf.svg)](https://anaconda.org/conda-forge/nbconvert-qtpdf) | [![Conda Version](https://img.shields.io/conda/vn/conda-forge/nbconvert-qtpdf.svg)](https://anaconda.org/conda-forge/nbconvert-qtpdf) | [![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/nbconvert-qtpdf.svg)](https://anaconda.org/conda-forge/nbconvert-qtpdf) |
 
 Installing nbconvert
 ====================
@@ -73,16 +83,16 @@ conda config --add channels conda-forge
 conda config --set channel_priority strict
 ```
 
-Once the `conda-forge` channel has been enabled, `nbconvert, nbconvert-all, nbconvert-core, nbconvert-pandoc` can be installed with `conda`:
+Once the `conda-forge` channel has been enabled, `nbconvert, nbconvert-all, nbconvert-core, nbconvert-pandoc, nbconvert-qtpdf` can be installed with `conda`:
 
 ```
-conda install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc
+conda install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc nbconvert-qtpdf
 ```
 
 or with `mamba`:
 
 ```
-mamba install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc
+mamba install nbconvert nbconvert-all nbconvert-core nbconvert-pandoc nbconvert-qtpdf
 ```
 
 It is possible to list all of the versions of `nbconvert` available on your platform with `conda`:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set version = "7.7.1" %}
-{% set build = 0 %}
 
 {% set min_pandoc = "2.14.2" %}
 {% set max_pandoc = "4.0.0" %}
@@ -13,7 +12,7 @@ source:
   sha256: b820b206bd16898d39198a732dac6fb7019e82a44a282f606d931b8113240295
 
 build:
-  number: {{ build }}
+  number: 1
   noarch: python
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,7 +82,8 @@ outputs:
       run_constrained:
         # other packages carry the full `run` dependency
         - pandoc >={{ min_pandoc }},<{{ max_pandoc }}
-        - pyppeteer >=1,<1.1
+        # TODO: restore after https://github.com/conda-forge/staged-recipes/issues/23382
+        # - playwright-python >=???,<???
         # avoid mixing nbconvert-core and pre-split nbconvert
         # should be {{ pin_subpackage("nbconvert", exact=True) }}
         # but seems to produce the wrong thing here
@@ -104,29 +105,30 @@ outputs:
         - jupyter nbconvert --help
         - jupyter dejavu --help
 
-  - name: nbconvert-webpdf
-    build:
-      noarch: python
-    requirements:
-      host:
-        - python >=3.8
-        - pip
-      run:
-        - {{ pin_subpackage("nbconvert-core", exact=True) }}
-        # the pin is handled by the `run_constrained` in nbconvert-core
-        - pyppeteer
-        - python >=3.8
-    test:
-      requires:
-        - pip
-      commands:
-        - pip check
-        - jupyter nbconvert --version
-        - jupyter dejavu --version
-        - jupyter nbconvert --help
-        - jupyter dejavu --help
-    about:
-      description: nbconvert with extra packages for browser-based PDF generation
+  # TODO: restore after https://github.com/conda-forge/staged-recipes/issues/23382
+  # - name: nbconvert-webpdf
+  #   build:
+  #     noarch: python
+  #   requirements:
+  #     host:
+  #       - python >=3.8
+  #       - pip
+  #     run:
+  #       - {{ pin_subpackage("nbconvert-core", exact=True) }}
+  #       # the pin is handled by the `run_constrained` in nbconvert-core
+  #       - playwright-python
+  #       - python >=3.8
+  #   test:
+  #     requires:
+  #       - pip
+  #     commands:
+  #       - pip check
+  #       - jupyter nbconvert --version
+  #       - jupyter dejavu --version
+  #       - jupyter nbconvert --help
+  #       - jupyter dejavu --help
+  #   about:
+  #     description: nbconvert with extra packages for browser-based PDF generation
 
   - name: nbconvert-pandoc
     build:
@@ -163,7 +165,8 @@ outputs:
         - pip
         - python >=3.8
       run:
-        - {{ pin_subpackage("nbconvert-webpdf", exact=True) }}
+        # TODO: restore after https://github.com/conda-forge/staged-recipes/issues/23382
+        # - {{ pin_subpackage("nbconvert-webpdf", exact=True) }}
         - {{ pin_subpackage("nbconvert", exact=True) }}
         - python >=3.8
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -153,7 +153,8 @@ outputs:
         - jupyter dejavu --version
         - jupyter nbconvert --help
         - jupyter dejavu --help
-        - jupyter nbconvert nbconvert/tests/files/notebook1.ipynb --to qtpdf
+        - jupyter nbconvert nbconvert/tests/files/notebook1.ipynb --to qtpdf  # [not linux]
+        - DISPLAY=localhost:1.0 xvfb-run -a jupyter nbconvert nbconvert/tests/files/notebook1.ipynb --to qtpdf  # [linux]
     about:
       description: nbconvert with extra packages for browser-based PDF generation
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -3,6 +3,8 @@
 {% set min_pandoc = "2.14.2" %}
 {% set max_pandoc = "4.0.0" %}
 
+{% set build = 1 %}
+
 package:
   name: nbconvert-meta
   version: {{ version }}
@@ -12,7 +14,7 @@ source:
   sha256: b820b206bd16898d39198a732dac6fb7019e82a44a282f606d931b8113240295
 
 build:
-  number: 1
+  number: {{ build }}
   noarch: python
 
 requirements:
@@ -129,6 +131,32 @@ outputs:
   #   about:
   #     description: nbconvert with extra packages for browser-based PDF generation
 
+  - name: nbconvert-qtpdf
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python >=3.8
+        - pip
+      run:
+        - {{ pin_subpackage("nbconvert-core", exact=True) }}
+        - pyqtwebengine >=5.5
+        - python >=3.8
+    test:
+      source_files:
+        - nbconvert/tests/files/notebook1.ipynb
+      requires:
+        - pip
+      commands:
+        - pip check
+        - jupyter nbconvert --version
+        - jupyter dejavu --version
+        - jupyter nbconvert --help
+        - jupyter dejavu --help
+        - jupyter nbconvert nbconvert/tests/files/notebook1.ipynb --to qtpdf
+    about:
+      description: nbconvert with extra packages for browser-based PDF generation
+
   - name: nbconvert-pandoc
     build:
       noarch: python
@@ -166,6 +194,7 @@ outputs:
       run:
         # TODO: restore after https://github.com/conda-forge/staged-recipes/issues/23382
         # - {{ pin_subpackage("nbconvert-webpdf", exact=True) }}
+        - {{ pin_subpackage("nbconvert-qtpdf", exact=True) }}
         - {{ pin_subpackage("nbconvert", exact=True) }}
         - python >=3.8
     test:

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,0 +1,1 @@
+mesa-libGL

--- a/recipe/yum_requirements.txt
+++ b/recipe/yum_requirements.txt
@@ -1,1 +1,2 @@
 mesa-libGL
+xorg-x11-server-Xvfb


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

- removes broken `nbconvert-webpdf`.
  - leaves notes pointing at https://github.com/conda-forge/staged-recipes/issues/23382

As a follow-up to https://github.com/conda-forge/nbconvert-feedstock/pull/108#issuecomment-1638403173  `nbconvert-webpdf 7.7.1=*_0` should be marked broken.