### PR TITLE
Fix 'about' sections.

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,3 +1,7 @@
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -6,3 +10,6 @@ channel_targets:
 - conda-forge main
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
+zip_keys:
+- - c_stdlib_version
+  - cdt_name

--- a/README.md
+++ b/README.md
@@ -25,27 +25,39 @@ formats via Jinja templates. The nbconvert tool allows you to convert an
 About nbconvert-pandoc
 ----------------------
 
+Home: https://jupyter.org
 
+Package license: BSD-3-Clause
 
-Package license: 
+Development: https://github.com/jupyter/nbconvert
+
+Documentation: https://nbconvert.readthedocs.org/
 
 nbconvert with extra packages for pandoc-based outputs
 
 About nbconvert-qtpdf
 ---------------------
 
+Home: https://jupyter.org
 
+Package license: BSD-3-Clause
 
-Package license: 
+Development: https://github.com/jupyter/nbconvert
+
+Documentation: https://nbconvert.readthedocs.org/
 
 nbconvert with extra packages for browser-based PDF generation
 
 About nbconvert-all
 -------------------
 
+Home: https://jupyter.org
 
+Package license: BSD-3-Clause
 
-Package license: 
+Development: https://github.com/jupyter/nbconvert
+
+Documentation: https://nbconvert.readthedocs.org/
 
 nbconvert with all optional packages
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -154,7 +154,12 @@ outputs:
         - jupyter nbconvert tests/files/notebook1.ipynb --to qtpdf  # [not linux]
         - xvfb-run -a jupyter nbconvert tests/files/notebook1.ipynb --to qtpdf  # [linux]
     about:
+      home: https://jupyter.org
+      license: BSD-3-Clause
+      license_file: LICENSE
       description: nbconvert with extra packages for browser-based PDF generation
+      doc_url: https://nbconvert.readthedocs.org/
+      dev_url: https://github.com/jupyter/nbconvert
 
   - name: nbconvert-pandoc
     build:
@@ -177,7 +182,12 @@ outputs:
         - jupyter dejavu --help
         - python check_pandoc.py ">={{ min_pandoc }}" "<{{ max_pandoc }}"
     about:
+      home: https://jupyter.org
+      license: BSD-3-Clause
+      license_file: LICENSE
       description: nbconvert with extra packages for pandoc-based outputs
+      doc_url: https://nbconvert.readthedocs.org/
+      dev_url: https://github.com/jupyter/nbconvert
 
   - name: nbconvert-all
     build:
@@ -209,7 +219,12 @@ outputs:
         - xvfb-run -a coverage run --branch --source=nbconvert -m pytest -vv {{ pytest_args }}  # [linux]
         - coverage report --show-missing --skip-covered --fail-under={{ cov_fail_under }}       # [linux]
     about:
+      home: https://jupyter.org
+      license: BSD-3-Clause
+      license_file: LICENSE
       description: nbconvert with all optional packages
+      doc_url: https://nbconvert.readthedocs.org/
+      dev_url: https://github.com/jupyter/nbconvert
 
 about:
   home: https://jupyter.org

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@
 {% set min_pandoc = "2.9.2" %}
 {% set max_pandoc = "4.0.0" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 
 {% set pytest_args = "-k \"not (convert_full_qualified_name or post_processor)\"" %}
 {% set cov_fail_under = "71" %}


### PR DESCRIPTION
The current about sections conflict in a way that makes it impossible for the license information to be properly propagated to the `repodata.json`.
This is why e.g. for `nbconvert-pandoc` searched in the [conda-metadata-browser](https://conda-metadata-app.streamlit.app/?q=conda-forge%2Fnoarch%2Fnbconvert-pandoc-7.16.3-hd8ed1ab_0.conda) no license file is shown.
This PR should fix this issue by duplicating license and other information to the respective sections in the `meta.yaml`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
