### PR TITLE
Add missing `about`s to split packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,7 @@ Development: https://github.com/jupyter/nbconvert
 
 Documentation: https://nbconvert.readthedocs.org/
 
-The nbconvert tool, jupyter nbconvert, converts notebooks to various other
-formats via Jinja templates. The nbconvert tool allows you to convert an
-.ipynb notebook file into various static formats.
+nbconvert with pandoc
 
 About nbconvert-all
 -------------------
@@ -35,6 +33,21 @@ Development: https://github.com/jupyter/nbconvert
 Documentation: https://nbconvert.readthedocs.org/
 
 nbconvert with all optional packages
+
+About nbconvert-core
+--------------------
+
+Home: https://jupyter.org/
+
+Package license: BSD-3-Clause
+
+Summary: Converting Jupyter Notebooks
+
+Development: https://github.com/jupyter/nbconvert
+
+Documentation: https://nbconvert.readthedocs.org/
+
+nbconvert core
 
 About nbconvert-pandoc
 ----------------------

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -50,6 +50,13 @@ outputs:
           - jupyter dejavu --version
           - jupyter nbconvert --help
           - jupyter dejavu --help
+    about:
+      license: BSD-3-Clause
+      license_file: LICENSE
+      description: nbconvert with pandoc
+      homepage: https://jupyter.org
+      repository: https://github.com/jupyter/nbconvert
+      documentation: https://nbconvert.readthedocs.org
 
   - package:
       name: nbconvert-core
@@ -110,6 +117,13 @@ outputs:
           - jupyter dejavu --version
           - jupyter nbconvert --help
           - jupyter dejavu --help
+    about:
+      license: BSD-3-Clause
+      license_file: LICENSE
+      description: nbconvert core
+      homepage: https://jupyter.org
+      repository: https://github.com/jupyter/nbconvert
+      documentation: https://nbconvert.readthedocs.org
 
   - package:
       name: nbconvert-qtpdf

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -4,7 +4,7 @@ schema_version: 1
 context:
   version: "7.17.1"
   # needed for "soft" `pin_depends`
-  build: "0"
+  build: "1"
   python_check_max: "3.14"
   # out-of-band deps
   min_pandoc: "2.9.2"


### PR DESCRIPTION
Adds missing `about`s to metapackages. This should fill in metadata (like descriptions and licenses) for a few packages that were missing them.

<hr>

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Fixes https://github.com/conda-forge/nbconvert-feedstock/issues/86

<!--
Please add any other relevant info below:
-->